### PR TITLE
課題Issueを複製先Repoに丸ごとコピーするGithubActionsを追加

### DIFF
--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -1,0 +1,177 @@
+name: "Copy issues"
+on:
+  workflow_dispatch:
+
+jobs:
+  get-issue-labels:
+    if: github.repository != 'yumemi-inc/android-engineer-codecheck'
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.output_label_data.outputs.value }}
+    steps:
+    - name: Getting Labels data
+      id: get_label_data
+      uses: octokit/request-action@v2.1.0
+      with:
+        route: GET /repos/yumemi-inc/android-engineer-codecheck/labels
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - id: output_label_data
+      run: |
+        result=$(echo '${{ steps.get_label_data.outputs.data }}' | sed -z 's/\n//g')
+        echo "::set-output name=value::${result}"
+
+  create-issue-labels:
+    needs: get-issue-labels
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        label: ${{ fromJson(needs.get-issue-labels.outputs.labels) }}
+    steps:
+    - name: Create a label
+      uses: octokit/request-action@v2.1.0
+      with:
+        route: POST /repos/${{ github.repository }}/labels
+        name: ${{ matrix.label.name }}
+        color: ${{ matrix.label.color }}
+        description: ${{ matrix.label.description }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  get-milestones:
+    if: github.repository != 'yumemi-inc/android-engineer-codecheck'
+    runs-on: ubuntu-latest
+    outputs:
+      milestones: ${{ steps.output_milestones_data.outputs.value }}
+    steps:
+    - name: Getting Milestones data
+      id: get_milestones_data
+      uses: octokit/request-action@v2.1.0
+      with:
+        route: GET /repos/yumemi-inc/android-engineer-codecheck/milestones
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - id: output_milestones_data
+      run: |
+        result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n//g')
+        echo "::set-output name=value::${result}"
+
+  create-milestones:
+    needs: get-milestones
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        milestone: ${{ fromJson(needs.get-milestones.outputs.milestones) }}
+    steps:
+    - name: Create a milestone
+      uses: octokit/request-action@v2.1.0
+      with:
+        route: POST /repos/${{ github.repository }}/milestones
+        title: ${{ matrix.milestone.title }}
+        description: ${{ matrix.milestone.description }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  get-myrepo-milestones:
+    needs: create-milestones
+    runs-on: ubuntu-latest
+    outputs:
+      milestones: ${{ steps.output_milestones_data.outputs.value }}
+    steps:
+    - name: Getting Milestones data
+      id: get_milestones_data
+      uses: octokit/request-action@v2.1.0
+      with:
+        route: GET /repos/${{ github.repository }}/milestones
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - id: output_milestones_data
+      run: |
+        result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
+        echo "::set-output name=value::${result}"
+
+  get-issues:
+    if: github.repository != 'yumemi-inc/android-engineer-codecheck'
+    runs-on: ubuntu-latest
+    outputs:
+      issues: ${{ steps.output_issues_data.outputs.value }}
+    steps:
+    - name: Getting issues data
+      id: get_issues_data
+      uses: octokit/request-action@v2.1.0
+      with:
+        route: GET /repos/yumemi-inc/android-engineer-codecheck/issues
+        sort: created
+        direction: asc
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - id: output_issues_data
+      run: |
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
+        echo "::set-output name=value::${result}"
+    - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
+
+  get-myrepo-issues:
+    if: github.repository != 'yumemi-inc/android-engineer-codecheck'
+    runs-on: ubuntu-latest
+    outputs:
+      issues: ${{ steps.output_issues_data.outputs.value }}
+    steps:
+    - name: Getting issues data
+      id: get_issues_data
+      uses: octokit/request-action@v2.1.0
+      with:
+        route: GET /repos/${{ github.repository }}/issues
+        state: all
+        per_page: 100
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - id: output_issues_data
+      run: |
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
+        echo "::set-output name=value::${result}"
+    - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
+
+  create-issues:
+    needs: [create-issue-labels, get-myrepo-milestones, get-issues, get-myrepo-issues]
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix: 
+        issue: ${{ fromJson(needs.get-issues.outputs.issues) }}
+    steps:
+    - name: Find milestone
+      id: find-milestone
+      run: |
+        milestones='${{ needs.get-myrepo-milestones.outputs.milestones }}'
+        milestone_number=$(echo ${milestones} | jq '.[] | select (.title=="${{ matrix.issue.milestone.title }}") | .number' )
+        echo "::set-output name=number::${milestone_number}"
+    - name: Create a issue
+      if: ${{ matrix.issue.pull_request == null }}
+      run: |
+        body=$(echo '${{ matrix.issue.body }}')
+        body="${body//$'\n'/\\n}"
+        body="${body//$'\r'/\\r}"
+        
+        if [[ "$body" =~ '#'[0-9] ]]; then
+            link=$(echo "$body" | grep -o "#[0-9]")
+            num=$(echo $link | tr -d '#')
+
+            issues=$(echo '${{ needs.get-issues.outputs.issues }}' | jq '[ . as $d | keys[] | $d[.] + {index:.} ]')
+            issue_index=$(echo "$issues" | jq ".[] | select (.number==${num}) | .index")
+            my_issue_count=$(echo '${{ needs.get-myrepo-issues.outputs.issues }}' | jq '. | length')
+
+            num=$(($issue_index+$my_issue_count+1))
+            body=$(echo $body | sed "s/$link/#${num}/g")
+        fi
+
+        labels='${{ toJson(matrix.issue.labels.*.name) }}'
+        curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/issues \
+          -d "{
+            \"title\" : \"${{ matrix.issue.title }}\",
+            \"body\" : \"$body\",
+            \"labels\" : ${labels},
+            \"milestone\" : ${{ steps.find-milestone.outputs.number }}
+          }"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Issues を確認した上、本プロジェクトを [**Duplicate** してくだ
 | 新卒／未経験者 | 必須 | 選択 | 選択 |
 | 中途／経験者 | 必須 | 必須 | 選択 |
 
+課題 Issueをご自身のリポジトリーにコピーするGitHub Actionsをご用意しております。  
+[こちらのWorkflow](./.github/workflows/copy-issues.yml)を[手動でトリガーする](https://docs.github.com/ja/actions/managing-workflow-runs/manually-running-a-workflow)ことでコピーできますのでご活用下さい。
+
 課題が完成したら、リポジトリのアドレスを教えてください。
 
 ## 参考記事


### PR DESCRIPTION
課題Issueを複製先Repoに丸ごとコピーするGithubActionsを追加しました。
iOS版にはすでに導入済みです
https://github.com/yumemi-inc/ios-engineer-codecheck/pull/13
https://github.com/yumemi-inc/ios-engineer-codecheck/pull/14

## 目的
- 課題に取り組み易いように
- 課題をレビューし易いように

## 複製の手順
今のところ、github actionsを[手動で実行](https://docs.github.com/ja/actions/managing-workflow-runs/manually-running-a-workflow)していただく想定です。
費用がかかる場合があるので、勝手に実行されることは避ける考えです。

## 実行結果サンプル
このリポジトリで実行しました
https://github.com/watanavex/android-issue-copy-test/issues
https://github.com/watanavex/android-issue-copy-test/actions/runs/1606461204