### PR TITLE
Copyrightの修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 YUMEMI Inc. All rights reserved.
+ * Copyright © 2022 YUMEMI Inc. All rights reserved.
  */
 package jp.co.yumemi.android.code_check
 


### PR DESCRIPTION
2022年にも使用しているため、著作権表示だけは新しくしたほうが良いと思います。