### PR TITLE
GITHUB_TOKEN に Issues への write 権限を追加

### DIFF
--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -24,6 +24,8 @@ jobs:
   create-issue-labels:
     needs: get-issue-labels
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       matrix: 
         label: ${{ fromJson(needs.get-issue-labels.outputs.labels) }}
@@ -59,6 +61,8 @@ jobs:
   create-milestones:
     needs: get-milestones
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       matrix: 
         milestone: ${{ fromJson(needs.get-milestones.outputs.milestones) }}
@@ -135,6 +139,8 @@ jobs:
   create-issues:
     needs: [create-issue-labels, get-myrepo-milestones, get-issues, get-myrepo-issues]
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       max-parallel: 1
       matrix: 


### PR DESCRIPTION
GITHUB_TOKEN の issues 作成に関する default permission が write ではなくなったので個別に指定するようにします。
 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication

Fork したリポジトリで変更後の Actions で課題のコピーができることを確認しました。
https://github.com/ykws/android-engineer-codecheck/actions/runs/4834395276

fixes #21 

iOS も同様の問題がありました。
- https://github.com/yumemi-inc/ios-engineer-codecheck/pull/21