### PR TITLE
GITHUB_TOKEN に Issues に対する read/write 権限を追加

### DIFF
--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -24,6 +24,8 @@ jobs:
   create-issue-labels:
     needs: get-issue-labels
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       matrix: 
         label: ${{ fromJson(needs.get-issue-labels.outputs.labels) }}
@@ -59,6 +61,8 @@ jobs:
   create-milestones:
     needs: get-milestones
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       matrix: 
         milestone: ${{ fromJson(needs.get-milestones.outputs.milestones) }}
@@ -135,6 +139,8 @@ jobs:
   create-issues:
     needs: [create-issue-labels, get-myrepo-milestones, get-issues, get-myrepo-issues]
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       max-parallel: 1
       matrix: 

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -79,6 +79,8 @@ jobs:
   get-myrepo-milestones:
     needs: create-milestones
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
     outputs:
       milestones: ${{ steps.output_milestones_data.outputs.value }}
     steps:
@@ -118,6 +120,8 @@ jobs:
   get-myrepo-issues:
     if: github.repository != 'yumemi-inc/android-engineer-codecheck'
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
     outputs:
       issues: ${{ steps.output_issues_data.outputs.value }}
     steps:


### PR DESCRIPTION
GITHUB_TOKEN の issues に関する default permission が none になったので、 **private** repository の場合、以下が 403 になります。
https://docs.github.com/en/actions/security-guides/automatic-token-authentication

- get-myrepo-issues
- get-myrepo-milestones

## GitHub Actions Failure Result
<img width="347" alt="Screenshot 2023-05-14 at 0 51 10" src="https://github.com/ykws/android-engineer-codecheck/assets/5770480/f76b95f0-8852-423c-a793-6fa7e74fecca">

## Notes
- yumemi-inc の方に feature/permissions-issues-write の branch がないので、 #23 の対応を含んでいます。
- **public** repository の場合は、アクセス可能なため、 https://github.com/yumemi-inc/android-engineer-codecheck/pull/23 の対応で十分になります。
- 手元の **private** repository で Copy issues の GitHub Actions からコピーできることを確認しました。
